### PR TITLE
Add infinite scrolling in DealsFeed

### DIFF
--- a/src/global-state/dealsFeed.tsx
+++ b/src/global-state/dealsFeed.tsx
@@ -60,7 +60,9 @@ export class DealsFeed {
       meta: feed1.meta,
       deals: feed1.deals
         .filter(d1 => feed2.deals.every(d2 => d1.id !== d2.id))
-        .concat(feed2.deals),
+        .concat(feed2.deals)
+        // Keep deals sorted in highest -> lowest order (newest -> oldest deals)
+        .sort(({ id: idA }, { id: idB }) => idB - idA),
     };
   }
 }
@@ -161,7 +163,7 @@ async function loadFeedNextPage(
 
   dispatch({
     type: 'set',
-    dealsFeed: new DealsFeed(dealsFeed.feed, newFeed, lastFetchedPage),
+    dealsFeed: new DealsFeed(dealsFeed.feed, newFeed, lastFetchedPage + 1),
   });
 }
 

--- a/src/global-state/dealsFeed.tsx
+++ b/src/global-state/dealsFeed.tsx
@@ -94,6 +94,7 @@ export const localFetchFeed: FeedFetcher = async () => {
   return feed;
 };
 
+// Ozbargain feeds seem to have a 20 page limit (0 - 19) before 404ing.
 export const onlineFetchFeed: FeedFetcher = (page = 0) => {
   return getOzbargainFeedFromUrl(`${FEED_URL_NEW_DEALS}?page=${page}`);
 };

--- a/src/screens/dealsFeed/dealsFeed.tsx
+++ b/src/screens/dealsFeed/dealsFeed.tsx
@@ -43,6 +43,9 @@ export function DealsFeed({
       contentContainerStyle={style}
       onRefresh={onRefresh}
       onEndReached={() => loadNextPage()}
+      // This value felt about right, with new deals being fetched a little before reaching the end.
+      // After manual testing, couldn't figure out exactly how this value relates to how many deals are on screen.
+      // So this number might need to change if the size of deal cards changes.
       onEndReachedThreshold={3}
       refreshing={refreshing}
     />

--- a/src/screens/dealsFeed/dealsFeed.tsx
+++ b/src/screens/dealsFeed/dealsFeed.tsx
@@ -14,6 +14,7 @@ export type DealsFeedProps = {
   items: DealItemData[];
   onPressItem: (item: DealItemData) => void;
   onRefresh: NonNullable<FlatListProps<DealItemData>['onRefresh']>;
+  loadNextPage: () => void;
   refreshing: NonNullable<FlatListProps<DealItemData>['refreshing']>;
   style?: FlatListProps<DealItemData>['contentContainerStyle'];
 };
@@ -22,6 +23,7 @@ export function DealsFeed({
   items,
   onPressItem,
   onRefresh,
+  loadNextPage,
   refreshing,
   style,
 }: DealsFeedProps): JSX.Element {
@@ -40,6 +42,12 @@ export function DealsFeed({
       ItemSeparatorComponent={FeedItemSeparator}
       contentContainerStyle={style}
       onRefresh={onRefresh}
+      onEndReached={() => {
+        // onEndReached will fire when there are 0 items to render (so list length is 0)
+        if (items.length > 0) {
+          loadNextPage();
+        }
+      }}
       refreshing={refreshing}
     />
   );

--- a/src/screens/dealsFeed/dealsFeed.tsx
+++ b/src/screens/dealsFeed/dealsFeed.tsx
@@ -42,12 +42,8 @@ export function DealsFeed({
       ItemSeparatorComponent={FeedItemSeparator}
       contentContainerStyle={style}
       onRefresh={onRefresh}
-      onEndReached={() => {
-        // onEndReached will fire when there are 0 items to render (so list length is 0)
-        if (items.length > 0) {
-          loadNextPage();
-        }
-      }}
+      onEndReached={() => loadNextPage()}
+      onEndReachedThreshold={3}
       refreshing={refreshing}
     />
   );

--- a/src/screens/dealsFeed/screen.tsx
+++ b/src/screens/dealsFeed/screen.tsx
@@ -5,7 +5,7 @@ import { useDealsFeed } from '../../global-state/dealsFeed';
 import { Button } from '../../base/components/button/button';
 
 export function FeedScreen({ navigation }: FeedScreenProps): JSX.Element {
-  const { state, dealsFeed, refresh } = useDealsFeed();
+  const { state, dealsFeed, refresh, loadNextPage } = useDealsFeed();
 
   return (
     <>
@@ -26,6 +26,9 @@ export function FeedScreen({ navigation }: FeedScreenProps): JSX.Element {
           navigation.navigate('DealInfo', { dealId: item.id })
         }
         onRefresh={refresh}
+        loadNextPage={() =>
+          state === 'ready' ? loadNextPage(dealsFeed) : undefined
+        }
         refreshing={state === 'refreshing'}
       />
     </>


### PR DESCRIPTION
It just works (TM)

- Refactor pull-to-refresh to discard current cached feed and start fresh from feed page 0.
- Reaching the end of the list (actually a bit before the end) will request to load the next page of the feed.