### PR TITLE
Add @testing-library/react-native devDep, and initial unit tests for DealCard component

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,7 +22,10 @@
     },
     "ecmaVersion": "latest",
     "sourceType": "module",
-    "project": "./tsconfig.json"
+    "project": [
+      "./tsconfig.json",
+      "./tsconfig.eslint.json"
+    ]
   },
   "rules": {
     "import/no-unresolved": 0,
@@ -82,5 +85,18 @@
       "error",
       "never"
     ]
-  }
+  },
+  "overrides": [
+    {
+      "files": [
+        "*.test.ts",
+        "*.test.tsx"
+      ],
+      "rules": {
+        // Disabled for tests because the return type of `screen.*` methods from `@testing-library/react-native`
+        // is incorrectly `any` inside eslint. Typescript does narrow the type correctly.
+        "@typescript-eslint/no-unsafe-assignment": "off"
+      }
+    }
+  ]
 }

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,7 +1,14 @@
 import type { Config } from 'jest';
 
 const config: Config = {
-  preset: 'jest-expo/universal',
+  projects: [
+    { preset: 'jest-expo/android' },
+    { preset: 'jest-expo/ios' },
+    {
+      preset: 'jest-expo/web',
+      testMatch: ['**/__tests__/**/*.test.(web|node).ts?(x)'],
+    },
+  ],
   setupFilesAfterEnv: ['@testing-library/jest-native/extend-expect'],
 };
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,3 +1,8 @@
-export default {
+import type { Config } from 'jest';
+
+const config: Config = {
   preset: 'jest-expo/universal',
+  setupFilesAfterEnv: ['@testing-library/jest-native/extend-expect'],
 };
+
+export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "expo-status-bar": "~1.4.4",
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "react-native": "0.71.4",
+        "react-native": "0.71.6",
         "react-native-safe-area-context": "4.5.0",
         "react-native-screens": "~3.20.0",
         "react-native-svg": "13.4.0",
@@ -26,6 +26,8 @@
       "devDependencies": {
         "@babel/core": "^7.21.3",
         "@expo/webpack-config": "^18.0.1",
+        "@testing-library/jest-native": "^5.4.2",
+        "@testing-library/react-native": "^12.0.1",
         "@types/feedparser": "^2.2.5",
         "@types/jest": "^29.5.0",
         "@types/react": "^18.0.28",
@@ -45,7 +47,7 @@
         "patch-package": "^6.5.1",
         "prettier": "^2.8.6",
         "ts-node": "^10.9.1",
-        "typescript": "^5.0.2"
+        "typescript": "^4.9.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -5501,16 +5503,16 @@
       }
     },
     "node_modules/@react-native-community/cli": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-10.2.0.tgz",
-      "integrity": "sha512-QH7AFBz5FX2zTZRH/o3XehHrZ0aZZEL5Sh+23nSEFgSj3bLFfvjjZhuoiRSAo7iiBdvAoXrfxQ8TXgg4Xf/7fw==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-10.2.2.tgz",
+      "integrity": "sha512-aZVcVIqj+OG6CrliR/Yn8wHxrvyzbFBY9cj7n0MvRw/P54QUru2nNqUTSSbqv0Qaa297yHJbe6kFDojDMSTM8Q==",
       "dependencies": {
         "@react-native-community/cli-clean": "^10.1.1",
         "@react-native-community/cli-config": "^10.1.1",
         "@react-native-community/cli-debugger-ui": "^10.0.0",
-        "@react-native-community/cli-doctor": "^10.2.0",
+        "@react-native-community/cli-doctor": "^10.2.2",
         "@react-native-community/cli-hermes": "^10.2.0",
-        "@react-native-community/cli-plugin-metro": "^10.2.0",
+        "@react-native-community/cli-plugin-metro": "^10.2.2",
         "@react-native-community/cli-server-api": "^10.1.1",
         "@react-native-community/cli-tools": "^10.1.1",
         "@react-native-community/cli-types": "^10.0.0",
@@ -5711,19 +5713,6 @@
         "strip-ansi": "^5.2.0",
         "sudo-prompt": "^9.0.0",
         "wcwidth": "^1.0.1"
-      }
-    },
-    "node_modules/@react-native-community/cli-doctor/node_modules/@react-native-community/cli-platform-ios": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-10.2.1.tgz",
-      "integrity": "sha512-hz4zu4Y6eyj7D0lnZx8Mf2c2si8y+zh/zUTgCTaPPLzQD8jSZNNBtUUiA1cARm2razpe8marCZ1QbTMAGbf3mg==",
-      "dependencies": {
-        "@react-native-community/cli-tools": "^10.1.1",
-        "chalk": "^4.1.2",
-        "execa": "^1.0.0",
-        "fast-xml-parser": "^4.0.12",
-        "glob": "^7.1.3",
-        "ora": "^5.4.1"
       }
     },
     "node_modules/@react-native-community/cli-doctor/node_modules/ansi-styles": {
@@ -6060,9 +6049,9 @@
       }
     },
     "node_modules/@react-native-community/cli-platform-ios": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-10.2.0.tgz",
-      "integrity": "sha512-hIPK3iL/mL+0ChXmQ9uqqzNOKA48H+TAzg+hrxQLll/6dNMxDeK9/wZpktcsh8w+CyhqzKqVernGcQs7tPeKGw==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-10.2.1.tgz",
+      "integrity": "sha512-hz4zu4Y6eyj7D0lnZx8Mf2c2si8y+zh/zUTgCTaPPLzQD8jSZNNBtUUiA1cARm2razpe8marCZ1QbTMAGbf3mg==",
       "dependencies": {
         "@react-native-community/cli-tools": "^10.1.1",
         "chalk": "^4.1.2",
@@ -6287,108 +6276,6 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/metro-react-native-babel-preset": {
-      "version": "0.73.9",
-      "resolved": "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.73.9.tgz",
-      "integrity": "sha512-AoD7v132iYDV4K78yN2OLgTPwtAKn0XlD2pOhzyBxiI8PeXzozhbKyPV7zUOJUPETj+pcEVfuYj5ZN/8+bhbCw==",
-      "dependencies": {
-        "@babel/core": "^7.20.0",
-        "@babel/plugin-proposal-async-generator-functions": "^7.0.0",
-        "@babel/plugin-proposal-class-properties": "^7.0.0",
-        "@babel/plugin-proposal-export-default-from": "^7.0.0",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
-        "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
-        "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
-        "@babel/plugin-proposal-optional-chaining": "^7.0.0",
-        "@babel/plugin-syntax-dynamic-import": "^7.0.0",
-        "@babel/plugin-syntax-export-default-from": "^7.0.0",
-        "@babel/plugin-syntax-flow": "^7.18.0",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.0.0",
-        "@babel/plugin-syntax-optional-chaining": "^7.0.0",
-        "@babel/plugin-transform-arrow-functions": "^7.0.0",
-        "@babel/plugin-transform-async-to-generator": "^7.0.0",
-        "@babel/plugin-transform-block-scoping": "^7.0.0",
-        "@babel/plugin-transform-classes": "^7.0.0",
-        "@babel/plugin-transform-computed-properties": "^7.0.0",
-        "@babel/plugin-transform-destructuring": "^7.0.0",
-        "@babel/plugin-transform-flow-strip-types": "^7.0.0",
-        "@babel/plugin-transform-function-name": "^7.0.0",
-        "@babel/plugin-transform-literals": "^7.0.0",
-        "@babel/plugin-transform-modules-commonjs": "^7.0.0",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.0.0",
-        "@babel/plugin-transform-parameters": "^7.0.0",
-        "@babel/plugin-transform-react-display-name": "^7.0.0",
-        "@babel/plugin-transform-react-jsx": "^7.0.0",
-        "@babel/plugin-transform-react-jsx-self": "^7.0.0",
-        "@babel/plugin-transform-react-jsx-source": "^7.0.0",
-        "@babel/plugin-transform-runtime": "^7.0.0",
-        "@babel/plugin-transform-shorthand-properties": "^7.0.0",
-        "@babel/plugin-transform-spread": "^7.0.0",
-        "@babel/plugin-transform-sticky-regex": "^7.0.0",
-        "@babel/plugin-transform-template-literals": "^7.0.0",
-        "@babel/plugin-transform-typescript": "^7.5.0",
-        "@babel/plugin-transform-unicode-regex": "^7.0.0",
-        "@babel/template": "^7.0.0",
-        "react-refresh": "^0.4.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "*"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/metro-react-native-babel-transformer": {
-      "version": "0.73.9",
-      "resolved": "https://registry.npmjs.org/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.73.9.tgz",
-      "integrity": "sha512-DSdrEHuQ22ixY7DyipyKkIcqhOJrt5s6h6X7BYJCP9AMUfXOwLe2biY3BcgJz5GOXv8/Akry4vTCvQscVS1otQ==",
-      "dependencies": {
-        "@babel/core": "^7.20.0",
-        "babel-preset-fbjs": "^3.4.0",
-        "hermes-parser": "0.8.0",
-        "metro-babel-transformer": "0.73.9",
-        "metro-react-native-babel-preset": "0.73.9",
-        "metro-source-map": "0.73.9",
-        "nullthrows": "^1.1.1"
-      },
-      "peerDependencies": {
-        "@babel/core": "*"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/metro-runtime": {
-      "version": "0.73.9",
-      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.73.9.tgz",
-      "integrity": "sha512-d5Hs83FpKB9r8q8Vb95+fa6ESpwysmPr4lL1I2rM2qXAFiO7OAPT9Bc23WmXgidkBtD0uUFdB2lG+H1ATz8rZg==",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "react-refresh": "^0.4.0"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/metro-source-map": {
-      "version": "0.73.9",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.73.9.tgz",
-      "integrity": "sha512-l4VZKzdqafipriETYR6lsrwtavCF1+CMhCOY9XbyWeTrpGSNgJQgdeJpttzEZTHQQTLR0csQo0nD1ef3zEP6IQ==",
-      "dependencies": {
-        "@babel/traverse": "^7.20.0",
-        "@babel/types": "^7.20.0",
-        "invariant": "^2.2.4",
-        "metro-symbolicate": "0.73.9",
-        "nullthrows": "^1.1.1",
-        "ob1": "0.73.9",
-        "source-map": "^0.5.6",
-        "vlq": "^1.0.0"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/ob1": {
-      "version": "0.73.9",
-      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.73.9.tgz",
-      "integrity": "sha512-kHOzCOFXmAM26fy7V/YuXNKne2TyRiXbFAvPBIbuedJCZZWQZHLdPzMeXJI4Egt6IcfDttRzN3jQ90wOwq1iNw=="
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/@react-native-community/cli-plugin-metro/node_modules/supports-color": {
@@ -6883,6 +6770,178 @@
       "dependencies": {
         "@sinonjs/commons": "^2.0.0"
       }
+    },
+    "node_modules/@testing-library/jest-native": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-native/-/jest-native-5.4.2.tgz",
+      "integrity": "sha512-Vo/CE1uvCVH1H8YPoOEXLXVsm+BjzSQTq35+wkri1fr0O5D+A2WZ+m3ni5g6f1OCzNKNGIAHmisBEWkDs1P1mw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "jest-diff": "^29.0.1",
+        "jest-matcher-utils": "^29.0.1",
+        "pretty-format": "^29.0.3",
+        "redent": "^3.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0",
+        "react-native": ">=0.59",
+        "react-test-renderer": ">=16.0.0"
+      }
+    },
+    "node_modules/@testing-library/jest-native/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/jest-native/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/jest-native/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@testing-library/jest-native/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@testing-library/jest-native/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/jest-native/node_modules/pretty-format": {
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.5.0.tgz",
+      "integrity": "sha512-V2mGkI31qdttvTFX7Mt4efOqHXqJWMu4/r66Xh3Z3BwZaPfPJgp6/gbwoujRpPUtfEF6AUUWx3Jim3GCw5g/Qw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^29.4.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@testing-library/jest-native/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/jest-native/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
+    },
+    "node_modules/@testing-library/jest-native/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/react-native": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-native/-/react-native-12.0.1.tgz",
+      "integrity": "sha512-IPyKF/WsxfpABf4VJUNgerLDoac/KusgZbLSkfbHCXboNBVKQZjdXGfp8C30Ih6xHnhjJAwO/Ff3dJGGGyXDkA==",
+      "dev": true,
+      "dependencies": {
+        "pretty-format": "^29.0.0"
+      },
+      "peerDependencies": {
+        "jest": ">=28.0.0",
+        "react": ">=16.8.0",
+        "react-native": ">=0.59",
+        "react-test-renderer": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "jest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/pretty-format": {
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.5.0.tgz",
+      "integrity": "sha512-V2mGkI31qdttvTFX7Mt4efOqHXqJWMu4/r66Xh3Z3BwZaPfPJgp6/gbwoujRpPUtfEF6AUUWx3Jim3GCw5g/Qw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^29.4.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
     },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
@@ -13129,18 +13188,24 @@
       "integrity": "sha512-8EZzEP0eKkEEVX+drtd9mtuQ+/QrlfW/5MlwcwK5Nds6EkZ/tRzEexkzUY2mIssnAyVLT+TKHuRXmFNNXYUd6g=="
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.3.tgz",
-      "integrity": "sha512-LsNDahCiCcJPe8NO7HijcnukHB24tKbfDDA5IILx9dmW3Frb52lhbeX6MPNUSvyGNfav2VTYpJ/OqkRoVLrh2Q==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.2.tgz",
+      "integrity": "sha512-DLzIPtQqmvmdq3VUKR7T6omPK/VCRNqgFlGtbESfyhcH2R4I8EzK1/K6E8PkRCK2EabWrUHK32NjYRbEFnnz0Q==",
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "dependencies": {
         "strnum": "^1.0.5"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
-      },
-      "funding": {
-        "type": "paypal",
-        "url": "https://paypal.me/naturalintelligence"
       }
     },
     "node_modules/fastq": {
@@ -19578,34 +19643,6 @@
         "nullthrows": "^1.1.1"
       }
     },
-    "node_modules/metro-babel-transformer/node_modules/metro-source-map": {
-      "version": "0.73.9",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.73.9.tgz",
-      "integrity": "sha512-l4VZKzdqafipriETYR6lsrwtavCF1+CMhCOY9XbyWeTrpGSNgJQgdeJpttzEZTHQQTLR0csQo0nD1ef3zEP6IQ==",
-      "dependencies": {
-        "@babel/traverse": "^7.20.0",
-        "@babel/types": "^7.20.0",
-        "invariant": "^2.2.4",
-        "metro-symbolicate": "0.73.9",
-        "nullthrows": "^1.1.1",
-        "ob1": "0.73.9",
-        "source-map": "^0.5.6",
-        "vlq": "^1.0.0"
-      }
-    },
-    "node_modules/metro-babel-transformer/node_modules/ob1": {
-      "version": "0.73.9",
-      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.73.9.tgz",
-      "integrity": "sha512-kHOzCOFXmAM26fy7V/YuXNKne2TyRiXbFAvPBIbuedJCZZWQZHLdPzMeXJI4Egt6IcfDttRzN3jQ90wOwq1iNw=="
-    },
-    "node_modules/metro-babel-transformer/node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/metro-cache": {
       "version": "0.73.9",
       "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.73.9.tgz",
@@ -19645,15 +19682,6 @@
         "metro-cache": "0.73.9",
         "metro-core": "0.73.9",
         "metro-runtime": "0.73.9"
-      }
-    },
-    "node_modules/metro-config/node_modules/metro-runtime": {
-      "version": "0.73.9",
-      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.73.9.tgz",
-      "integrity": "sha512-d5Hs83FpKB9r8q8Vb95+fa6ESpwysmPr4lL1I2rM2qXAFiO7OAPT9Bc23WmXgidkBtD0uUFdB2lG+H1ATz8rZg==",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "react-refresh": "^0.4.0"
       }
     },
     "node_modules/metro-core": {
@@ -19967,31 +19995,68 @@
       }
     },
     "node_modules/metro-react-native-babel-transformer": {
-      "version": "0.73.8",
-      "resolved": "https://registry.npmjs.org/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.73.8.tgz",
-      "integrity": "sha512-oH/LCCJPauteAE28c0KJAiSrkV+1VJbU0PwA9UwaWnle+qevs/clpKQ8LrIr33YbBj4CiI1kFoVRuNRt5h4NFg==",
+      "version": "0.73.9",
+      "resolved": "https://registry.npmjs.org/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.73.9.tgz",
+      "integrity": "sha512-DSdrEHuQ22ixY7DyipyKkIcqhOJrt5s6h6X7BYJCP9AMUfXOwLe2biY3BcgJz5GOXv8/Akry4vTCvQscVS1otQ==",
       "dependencies": {
         "@babel/core": "^7.20.0",
         "babel-preset-fbjs": "^3.4.0",
         "hermes-parser": "0.8.0",
-        "metro-babel-transformer": "0.73.8",
-        "metro-react-native-babel-preset": "0.73.8",
-        "metro-source-map": "0.73.8",
+        "metro-babel-transformer": "0.73.9",
+        "metro-react-native-babel-preset": "0.73.9",
+        "metro-source-map": "0.73.9",
         "nullthrows": "^1.1.1"
       },
       "peerDependencies": {
         "@babel/core": "*"
       }
     },
-    "node_modules/metro-react-native-babel-transformer/node_modules/metro-babel-transformer": {
-      "version": "0.73.8",
-      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.73.8.tgz",
-      "integrity": "sha512-GO6H/W2RjZ0/gm1pIvdO9EP34s3XN6kzoeyxqmfqKfYhJmYZf1SzXbyiIHyMbJNwJVrsKuHqu32+GopTlKscWw==",
+    "node_modules/metro-react-native-babel-transformer/node_modules/metro-react-native-babel-preset": {
+      "version": "0.73.9",
+      "resolved": "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.73.9.tgz",
+      "integrity": "sha512-AoD7v132iYDV4K78yN2OLgTPwtAKn0XlD2pOhzyBxiI8PeXzozhbKyPV7zUOJUPETj+pcEVfuYj5ZN/8+bhbCw==",
       "dependencies": {
         "@babel/core": "^7.20.0",
-        "hermes-parser": "0.8.0",
-        "metro-source-map": "0.73.8",
-        "nullthrows": "^1.1.1"
+        "@babel/plugin-proposal-async-generator-functions": "^7.0.0",
+        "@babel/plugin-proposal-class-properties": "^7.0.0",
+        "@babel/plugin-proposal-export-default-from": "^7.0.0",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
+        "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+        "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
+        "@babel/plugin-proposal-optional-chaining": "^7.0.0",
+        "@babel/plugin-syntax-dynamic-import": "^7.0.0",
+        "@babel/plugin-syntax-export-default-from": "^7.0.0",
+        "@babel/plugin-syntax-flow": "^7.18.0",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.0.0",
+        "@babel/plugin-syntax-optional-chaining": "^7.0.0",
+        "@babel/plugin-transform-arrow-functions": "^7.0.0",
+        "@babel/plugin-transform-async-to-generator": "^7.0.0",
+        "@babel/plugin-transform-block-scoping": "^7.0.0",
+        "@babel/plugin-transform-classes": "^7.0.0",
+        "@babel/plugin-transform-computed-properties": "^7.0.0",
+        "@babel/plugin-transform-destructuring": "^7.0.0",
+        "@babel/plugin-transform-flow-strip-types": "^7.0.0",
+        "@babel/plugin-transform-function-name": "^7.0.0",
+        "@babel/plugin-transform-literals": "^7.0.0",
+        "@babel/plugin-transform-modules-commonjs": "^7.0.0",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.0.0",
+        "@babel/plugin-transform-parameters": "^7.0.0",
+        "@babel/plugin-transform-react-display-name": "^7.0.0",
+        "@babel/plugin-transform-react-jsx": "^7.0.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.0.0",
+        "@babel/plugin-transform-react-jsx-source": "^7.0.0",
+        "@babel/plugin-transform-runtime": "^7.0.0",
+        "@babel/plugin-transform-shorthand-properties": "^7.0.0",
+        "@babel/plugin-transform-spread": "^7.0.0",
+        "@babel/plugin-transform-sticky-regex": "^7.0.0",
+        "@babel/plugin-transform-template-literals": "^7.0.0",
+        "@babel/plugin-transform-typescript": "^7.5.0",
+        "@babel/plugin-transform-unicode-regex": "^7.0.0",
+        "@babel/template": "^7.0.0",
+        "react-refresh": "^0.4.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "*"
       }
     },
     "node_modules/metro-resolver": {
@@ -20003,46 +20068,27 @@
       }
     },
     "node_modules/metro-runtime": {
-      "version": "0.73.8",
-      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.73.8.tgz",
-      "integrity": "sha512-M+Bg9M4EN5AEpJ8NkiUsawD75ifYvYfHi05w6QzHXaqOrsTeaRbbeLuOGCYxU2f/tPg17wQV97/rqUQzs9qEtA==",
+      "version": "0.73.9",
+      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.73.9.tgz",
+      "integrity": "sha512-d5Hs83FpKB9r8q8Vb95+fa6ESpwysmPr4lL1I2rM2qXAFiO7OAPT9Bc23WmXgidkBtD0uUFdB2lG+H1ATz8rZg==",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
         "react-refresh": "^0.4.0"
       }
     },
     "node_modules/metro-source-map": {
-      "version": "0.73.8",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.73.8.tgz",
-      "integrity": "sha512-wozFXuBYMAy7b8BCYwC+qoXsvayVJBHWtSTlSLva99t+CoUSG9JO9kg1umzbOz28YYPxKmvb/wbnLMkHdas2cA==",
+      "version": "0.73.9",
+      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.73.9.tgz",
+      "integrity": "sha512-l4VZKzdqafipriETYR6lsrwtavCF1+CMhCOY9XbyWeTrpGSNgJQgdeJpttzEZTHQQTLR0csQo0nD1ef3zEP6IQ==",
       "dependencies": {
         "@babel/traverse": "^7.20.0",
         "@babel/types": "^7.20.0",
         "invariant": "^2.2.4",
-        "metro-symbolicate": "0.73.8",
+        "metro-symbolicate": "0.73.9",
         "nullthrows": "^1.1.1",
-        "ob1": "0.73.8",
+        "ob1": "0.73.9",
         "source-map": "^0.5.6",
         "vlq": "^1.0.0"
-      }
-    },
-    "node_modules/metro-source-map/node_modules/metro-symbolicate": {
-      "version": "0.73.8",
-      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.73.8.tgz",
-      "integrity": "sha512-xkBAcceYYp0GGdCCuMzkCF1ejHsd0lYlbKBkjSRgM0Nlj80VapPaSwumYoAvSaDxcbkvS7/sCjURGp5DsSFgRQ==",
-      "dependencies": {
-        "invariant": "^2.2.4",
-        "metro-source-map": "0.73.8",
-        "nullthrows": "^1.1.1",
-        "source-map": "^0.5.6",
-        "through2": "^2.0.1",
-        "vlq": "^1.0.0"
-      },
-      "bin": {
-        "metro-symbolicate": "src/index.js"
-      },
-      "engines": {
-        "node": ">=8.3"
       }
     },
     "node_modules/metro-source-map/node_modules/source-map": {
@@ -20071,26 +20117,6 @@
       "engines": {
         "node": ">=8.3"
       }
-    },
-    "node_modules/metro-symbolicate/node_modules/metro-source-map": {
-      "version": "0.73.9",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.73.9.tgz",
-      "integrity": "sha512-l4VZKzdqafipriETYR6lsrwtavCF1+CMhCOY9XbyWeTrpGSNgJQgdeJpttzEZTHQQTLR0csQo0nD1ef3zEP6IQ==",
-      "dependencies": {
-        "@babel/traverse": "^7.20.0",
-        "@babel/types": "^7.20.0",
-        "invariant": "^2.2.4",
-        "metro-symbolicate": "0.73.9",
-        "nullthrows": "^1.1.1",
-        "ob1": "0.73.9",
-        "source-map": "^0.5.6",
-        "vlq": "^1.0.0"
-      }
-    },
-    "node_modules/metro-symbolicate/node_modules/ob1": {
-      "version": "0.73.9",
-      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.73.9.tgz",
-      "integrity": "sha512-kHOzCOFXmAM26fy7V/YuXNKne2TyRiXbFAvPBIbuedJCZZWQZHLdPzMeXJI4Egt6IcfDttRzN3jQ90wOwq1iNw=="
     },
     "node_modules/metro-symbolicate/node_modules/source-map": {
       "version": "0.5.7",
@@ -20130,34 +20156,6 @@
         "metro-source-map": "0.73.9",
         "metro-transform-plugins": "0.73.9",
         "nullthrows": "^1.1.1"
-      }
-    },
-    "node_modules/metro-transform-worker/node_modules/metro-source-map": {
-      "version": "0.73.9",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.73.9.tgz",
-      "integrity": "sha512-l4VZKzdqafipriETYR6lsrwtavCF1+CMhCOY9XbyWeTrpGSNgJQgdeJpttzEZTHQQTLR0csQo0nD1ef3zEP6IQ==",
-      "dependencies": {
-        "@babel/traverse": "^7.20.0",
-        "@babel/types": "^7.20.0",
-        "invariant": "^2.2.4",
-        "metro-symbolicate": "0.73.9",
-        "nullthrows": "^1.1.1",
-        "ob1": "0.73.9",
-        "source-map": "^0.5.6",
-        "vlq": "^1.0.0"
-      }
-    },
-    "node_modules/metro-transform-worker/node_modules/ob1": {
-      "version": "0.73.9",
-      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.73.9.tgz",
-      "integrity": "sha512-kHOzCOFXmAM26fy7V/YuXNKne2TyRiXbFAvPBIbuedJCZZWQZHLdPzMeXJI4Egt6IcfDttRzN3jQ90wOwq1iNw=="
-    },
-    "node_modules/metro-transform-worker/node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/metro/node_modules/ansi-styles": {
@@ -20287,39 +20285,10 @@
         "@babel/core": "*"
       }
     },
-    "node_modules/metro/node_modules/metro-runtime": {
-      "version": "0.73.9",
-      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.73.9.tgz",
-      "integrity": "sha512-d5Hs83FpKB9r8q8Vb95+fa6ESpwysmPr4lL1I2rM2qXAFiO7OAPT9Bc23WmXgidkBtD0uUFdB2lG+H1ATz8rZg==",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "react-refresh": "^0.4.0"
-      }
-    },
-    "node_modules/metro/node_modules/metro-source-map": {
-      "version": "0.73.9",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.73.9.tgz",
-      "integrity": "sha512-l4VZKzdqafipriETYR6lsrwtavCF1+CMhCOY9XbyWeTrpGSNgJQgdeJpttzEZTHQQTLR0csQo0nD1ef3zEP6IQ==",
-      "dependencies": {
-        "@babel/traverse": "^7.20.0",
-        "@babel/types": "^7.20.0",
-        "invariant": "^2.2.4",
-        "metro-symbolicate": "0.73.9",
-        "nullthrows": "^1.1.1",
-        "ob1": "0.73.9",
-        "source-map": "^0.5.6",
-        "vlq": "^1.0.0"
-      }
-    },
     "node_modules/metro/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-    },
-    "node_modules/metro/node_modules/ob1": {
-      "version": "0.73.9",
-      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.73.9.tgz",
-      "integrity": "sha512-kHOzCOFXmAM26fy7V/YuXNKne2TyRiXbFAvPBIbuedJCZZWQZHLdPzMeXJI4Egt6IcfDttRzN3jQ90wOwq1iNw=="
     },
     "node_modules/metro/node_modules/rimraf": {
       "version": "3.0.2",
@@ -20461,6 +20430,15 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -20971,9 +20949,9 @@
       "dev": true
     },
     "node_modules/ob1": {
-      "version": "0.73.8",
-      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.73.8.tgz",
-      "integrity": "sha512-1F7j+jzD+edS6ohQP7Vg5f3yiIk5i3x1uLrNIHOmLHWzWK1t3zrDpjnoXghccdVlsU+UjbyURnDynm4p0GgXeA=="
+      "version": "0.73.9",
+      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.73.9.tgz",
+      "integrity": "sha512-kHOzCOFXmAM26fy7V/YuXNKne2TyRiXbFAvPBIbuedJCZZWQZHLdPzMeXJI4Egt6IcfDttRzN3jQ90wOwq1iNw=="
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -22964,14 +22942,14 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-native": {
-      "version": "0.71.4",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.71.4.tgz",
-      "integrity": "sha512-3hSYqvWrOdKhpV3HpEKp1/CkWx8Sr/N/miCrmUIAsVTSJUR7JW0VvIsrV9urDhUj/s6v2WF4n7qIEEJsmTCrPw==",
+      "version": "0.71.6",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.71.6.tgz",
+      "integrity": "sha512-gHrDj7qaAaiE41JwaFCh3AtvOqOLuRgZtHKzNiwxakG/wvPAYmG73ECfWHGxjxIx/QT17Hp37Da3ipCei/CayQ==",
       "dependencies": {
         "@jest/create-cache-key-function": "^29.2.1",
-        "@react-native-community/cli": "10.2.0",
+        "@react-native-community/cli": "10.2.2",
         "@react-native-community/cli-platform-android": "10.2.0",
-        "@react-native-community/cli-platform-ios": "10.2.0",
+        "@react-native-community/cli-platform-ios": "10.2.1",
         "@react-native/assets": "1.0.0",
         "@react-native/normalize-color": "2.1.0",
         "@react-native/polyfills": "2.0.0",
@@ -22984,16 +22962,16 @@
         "jest-environment-node": "^29.2.1",
         "jsc-android": "^250231.0.0",
         "memoize-one": "^5.0.0",
-        "metro-react-native-babel-transformer": "0.73.8",
-        "metro-runtime": "0.73.8",
-        "metro-source-map": "0.73.8",
+        "metro-react-native-babel-transformer": "0.73.9",
+        "metro-runtime": "0.73.9",
+        "metro-source-map": "0.73.9",
         "mkdirp": "^0.5.1",
         "nullthrows": "^1.1.1",
         "pretty-format": "^26.5.2",
         "promise": "^8.3.0",
         "react-devtools-core": "^4.26.1",
         "react-native-codegen": "^0.71.5",
-        "react-native-gradle-plugin": "^0.71.16",
+        "react-native-gradle-plugin": "^0.71.17",
         "react-refresh": "^0.4.0",
         "react-shallow-renderer": "^16.15.0",
         "regenerator-runtime": "^0.13.2",
@@ -23025,9 +23003,9 @@
       }
     },
     "node_modules/react-native-gradle-plugin": {
-      "version": "0.71.16",
-      "resolved": "https://registry.npmjs.org/react-native-gradle-plugin/-/react-native-gradle-plugin-0.71.16.tgz",
-      "integrity": "sha512-H2BjG2zk7B7Wii9sXvd9qhCVRQYDAHSWdMw9tscmZBqSP62DkIWEQSk4/B2GhQ4aK9ydVXgtqR6tBeg3yy8TSA=="
+      "version": "0.71.17",
+      "resolved": "https://registry.npmjs.org/react-native-gradle-plugin/-/react-native-gradle-plugin-0.71.17.tgz",
+      "integrity": "sha512-OXXYgpISEqERwjSlaCiaQY6cTY5CH6j73gdkWpK0hedxtiWMWgH+i5TOi4hIGYitm9kQBeyDu+wim9fA8ROFJA=="
     },
     "node_modules/react-native-safe-area-context": {
       "version": "4.5.0",
@@ -23244,6 +23222,19 @@
       },
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/regenerate": {
@@ -24717,6 +24708,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -25504,16 +25507,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
-      "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=12.20"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "expo-status-bar": "~1.4.4",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-native": "0.71.4",
+    "react-native": "0.71.6",
     "react-native-safe-area-context": "4.5.0",
     "react-native-screens": "~3.20.0",
     "react-native-svg": "13.4.0",
@@ -32,6 +32,8 @@
   "devDependencies": {
     "@babel/core": "^7.21.3",
     "@expo/webpack-config": "^18.0.1",
+    "@testing-library/jest-native": "^5.4.2",
+    "@testing-library/react-native": "^12.0.1",
     "@types/feedparser": "^2.2.5",
     "@types/jest": "^29.5.0",
     "@types/react": "^18.0.28",
@@ -51,7 +53,7 @@
     "patch-package": "^6.5.1",
     "prettier": "^2.8.6",
     "ts-node": "^10.9.1",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.4"
   },
   "private": true
 }

--- a/src/screens/dealsFeed/dealCard/__tests__/__snapshots__/dealCard.test.tsx.snap.android
+++ b/src/screens/dealsFeed/dealCard/__tests__/__snapshots__/dealCard.test.tsx.snap.android
@@ -1,0 +1,86 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Renders 1`] = `
+<View
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": undefined,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  testID="DEAL_CARD"
+>
+  <View
+    style={
+      {
+        "backgroundColor": "rgb(244, 244, 244)",
+        "borderColor": "orange",
+        "borderRadius": 8,
+        "borderWidth": 2,
+        "flexDirection": "row",
+        "gap": 16,
+        "height": 164,
+        "justifyContent": "space-between",
+        "maxHeight": 164,
+        "padding": 16,
+      }
+    }
+  >
+    <View
+      style={
+        {
+          "flexShrink": 1,
+        }
+      }
+    >
+      <Text
+        ellipsizeMode="tail"
+        numberOfLines={4}
+        style={
+          {
+            "fontSize": 14,
+            "fontWeight": "bold",
+            "marginBottom": 8,
+          }
+        }
+      >
+        my title
+      </Text>
+      <Text
+        ellipsizeMode="tail"
+        numberOfLines={3}
+        style={
+          {
+            "fontSize": 11,
+          }
+        }
+      >
+        my description
+      </Text>
+    </View>
+  </View>
+</View>
+`;

--- a/src/screens/dealsFeed/dealCard/__tests__/__snapshots__/dealCard.test.tsx.snap.ios
+++ b/src/screens/dealsFeed/dealCard/__tests__/__snapshots__/dealCard.test.tsx.snap.ios
@@ -1,0 +1,86 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Renders 1`] = `
+<View
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": undefined,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  testID="DEAL_CARD"
+>
+  <View
+    style={
+      {
+        "backgroundColor": "rgb(244, 244, 244)",
+        "borderColor": "orange",
+        "borderRadius": 8,
+        "borderWidth": 2,
+        "flexDirection": "row",
+        "gap": 16,
+        "height": 164,
+        "justifyContent": "space-between",
+        "maxHeight": 164,
+        "padding": 16,
+      }
+    }
+  >
+    <View
+      style={
+        {
+          "flexShrink": 1,
+        }
+      }
+    >
+      <Text
+        ellipsizeMode="tail"
+        numberOfLines={4}
+        style={
+          {
+            "fontSize": 14,
+            "fontWeight": "bold",
+            "marginBottom": 8,
+          }
+        }
+      >
+        my title
+      </Text>
+      <Text
+        ellipsizeMode="tail"
+        numberOfLines={3}
+        style={
+          {
+            "fontSize": 11,
+          }
+        }
+      >
+        my description
+      </Text>
+    </View>
+  </View>
+</View>
+`;

--- a/src/screens/dealsFeed/dealCard/__tests__/dealCard.test.tsx
+++ b/src/screens/dealsFeed/dealCard/__tests__/dealCard.test.tsx
@@ -1,6 +1,18 @@
 import { render, screen, fireEvent } from '@testing-library/react-native';
 import { DealCard, DEAL_CARD_TEST_ID } from '../dealCard';
 
+test('Renders', () => {
+  render(
+    <DealCard
+      title="my title"
+      description="my description"
+      onPress={jest.fn()}
+    />,
+  );
+
+  expect(screen.toJSON()).toMatchSnapshot();
+});
+
 test('Pressing anywhere on the card fires onPress', () => {
   const onPress = jest.fn();
   const descriptionText = 'desc';

--- a/src/screens/dealsFeed/dealCard/__tests__/dealCard.test.tsx
+++ b/src/screens/dealsFeed/dealCard/__tests__/dealCard.test.tsx
@@ -9,6 +9,9 @@ test('Pressing anywhere on the card fires onPress', () => {
     <DealCard title="title" description={descriptionText} onPress={onPress} />,
   );
 
+  // TODO: Figure out how to get the image to click on as well.
+  // `getBy` with all accessibility functions doesn't pick up the <Image> component.
+  // testID works but then seems to show up even when no image is given to the card.
   const description = screen.getByText(descriptionText);
   const card = screen.getByTestId(DEAL_CARD_TEST_ID);
 

--- a/src/screens/dealsFeed/dealCard/__tests__/dealCard.test.tsx
+++ b/src/screens/dealsFeed/dealCard/__tests__/dealCard.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen, fireEvent } from '@testing-library/react-native';
+import { DealCard, DEAL_CARD_TEST_ID } from '../dealCard';
+
+test('Pressing anywhere on the card fires onPress', () => {
+  const onPress = jest.fn();
+  const descriptionText = 'desc';
+
+  render(
+    <DealCard title="title" description={descriptionText} onPress={onPress} />,
+  );
+
+  const description = screen.getByText(descriptionText);
+  const card = screen.getByTestId(DEAL_CARD_TEST_ID);
+
+  fireEvent.press(description);
+  fireEvent.press(card);
+
+  expect(onPress).toHaveBeenCalledTimes(2);
+});

--- a/src/screens/dealsFeed/dealCard/dealCard.tsx
+++ b/src/screens/dealsFeed/dealCard/dealCard.tsx
@@ -1,6 +1,8 @@
 import { View, Text, StyleSheet, Pressable } from 'react-native';
 import { SquareImage } from '../../../base/components/image/squareImage';
 
+export const DEAL_CARD_TEST_ID = 'DEAL_CARD';
+
 export type DealCardProps = {
   title: string;
   description: string;
@@ -15,7 +17,7 @@ export function DealCard({
   imageUrl,
 }: DealCardProps): JSX.Element {
   return (
-    <Pressable onPress={onPress}>
+    <Pressable onPress={onPress} testID={DEAL_CARD_TEST_ID}>
       <View style={styles.card}>
         <TextSection title={title} description={description} />
         {imageUrl != null && (

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  // Allows eslint to run type-aware linting on top-level files
+  // that are not part of the actual project.
+  // See: https://typescript-eslint.io/linting/troubleshooting/#i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-file
+  "include": [
+    "*.ts"
+  ]
+}


### PR DESCRIPTION
Contributes to #12.

`@testing-library/*` libraries are well known for React automated tests. The `/react-native` library doesn't support as many functions as `/react` does, but it still seems to be well supported. In limited searching, it just seems that react native has a smaller ecosystem across the board.

To demonstrate use of the library, some unit tests for the `DealCard` component have been added. They are not exhaustive, more can be added in the future.