### PR TITLE
Vote Buttons change colour intensity based on amount of votes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -74,6 +74,7 @@
       "error",
       {
         "checksVoidReturn": {
+          "arguments": false,
           "attributes": false
         }
       }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
   "typescript.tsdk": "node_modules/typescript/lib",
-  "jest.jestCommandLine": "npm test --"
+  "jest.jestCommandLine": "npm test --",
+  // The logic in Jest config 'setupFilesAfterEnv' seemed to be lost on automatic (on save) re-runs in the default 'watch' mode. Manually re-running the tests in the plugin would work.
+  // Using this 'on-save' mode specifically seems to re-launch Jest for each run, which solves the issue. But, each test re-run is slower.
+  "jest.autoRun": "on-save"
 }

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -2,14 +2,19 @@ import type { Config } from 'jest';
 
 const config: Config = {
   projects: [
-    { preset: 'jest-expo/android' },
-    { preset: 'jest-expo/ios' },
+    {
+      preset: 'jest-expo/android',
+      setupFilesAfterEnv: ['<rootDir>/jest.setup-after-env.ts'],
+    },
+    {
+      preset: 'jest-expo/ios',
+      setupFilesAfterEnv: ['<rootDir>/jest.setup-after-env.ts'],
+    },
     {
       preset: 'jest-expo/web',
       testMatch: ['**/__tests__/**/*.test.(web|node).ts?(x)'],
     },
   ],
-  setupFilesAfterEnv: ['@testing-library/jest-native/extend-expect'],
 };
 
 export default config;

--- a/jest.setup-after-env.ts
+++ b/jest.setup-after-env.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import '@testing-library/jest-native/extend-expect';

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@types/feedparser": "^2.2.5",
         "@types/jest": "^29.5.0",
         "@types/react": "^18.0.28",
+        "@types/react-test-renderer": "^18.0.0",
         "@typescript-eslint/eslint-plugin": "^5.56.0",
         "@typescript-eslint/parser": "^5.56.0",
         "eslint": "^8.36.0",
@@ -7292,6 +7293,15 @@
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-test-renderer": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-18.0.0.tgz",
+      "integrity": "sha512-C7/5FBJ3g3sqUahguGi03O79b8afNeSD6T8/GU50oQrJCU0bVCCGQHaGKUbg2Ce8VQEEqTw8/HiS6lXHHdgkdQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/retry": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@types/feedparser": "^2.2.5",
     "@types/jest": "^29.5.0",
     "@types/react": "^18.0.28",
+    "@types/react-test-renderer": "^18.0.0",
     "@typescript-eslint/eslint-plugin": "^5.56.0",
     "@typescript-eslint/parser": "^5.56.0",
     "eslint": "^8.36.0",

--- a/src/base/assert.ts
+++ b/src/base/assert.ts
@@ -5,6 +5,7 @@ class AssertionError extends Error {
   }
 }
 
+/** An assertion that runs on browsers/mobile and in node. */
 export function assert(value: boolean, message?: string): asserts value {
   if (!value) {
     throw new AssertionError(message);

--- a/src/base/assert.ts
+++ b/src/base/assert.ts
@@ -1,0 +1,12 @@
+class AssertionError extends Error {
+  constructor(message?: string) {
+    super(message);
+    this.name = 'AssertionError';
+  }
+}
+
+export function assert(value: boolean, message?: string): asserts value {
+  if (!value) {
+    throw new AssertionError(message);
+  }
+}

--- a/src/base/components/button/__tests__/testHelpers.ts
+++ b/src/base/components/button/__tests__/testHelpers.ts
@@ -1,0 +1,39 @@
+import { Platform } from 'react-native';
+import type { ReactTestInstance } from 'react-test-renderer';
+import type { JestNativeMatchers } from '@testing-library/jest-native/extend-expect';
+import type { ButtonColours } from '../button';
+import { buttonColours } from '../button';
+import { assert } from '../../../assert';
+
+type ToHaveStyleParam = Parameters<JestNativeMatchers<void>['toHaveStyle']>[0];
+
+/**
+ * A helper for tests to check the colour of the base Button component, that accounts for platform differences.
+ * @param buttonTextElement The inner-most Text component on the Button. This is likely what you have if you used `*ByText` from @testing-library/react-native.
+ * @param colour The expected button colour.
+ */
+export function expectButtonColour(
+  buttonTextElement: ReactTestInstance,
+  colour: ButtonColours,
+): void {
+  const button = Platform.select({
+    ios: buttonTextElement,
+    default: buttonTextElement.parent?.parent,
+  });
+
+  assert(
+    button != null,
+    'Given element did not have expected parents. It is likely not an instance of the base Button component.',
+  );
+
+  expect(button).toHaveStyle(
+    Platform.select<ToHaveStyleParam>({
+      ios: {
+        color: buttonColours[colour],
+      },
+      default: {
+        backgroundColor: buttonColours[colour],
+      },
+    }),
+  );
+}

--- a/src/base/components/button/button.tsx
+++ b/src/base/components/button/button.tsx
@@ -1,7 +1,8 @@
 import { Button as ReactNativeButton, View, StyleSheet } from 'react-native';
 import type { ButtonProps as ReactNativeButtonProps } from 'react-native';
 
-const buttonColours = {
+/** Exported for testing. */
+export const buttonColours = {
   orange: '#ffbd59',
   green: '#82f152',
   lightGreen: '#a0ff77',

--- a/src/base/components/button/button.tsx
+++ b/src/base/components/button/button.tsx
@@ -1,12 +1,12 @@
-import { Button as ReactNativeButton } from 'react-native';
+import { Button as ReactNativeButton, View, StyleSheet } from 'react-native';
 import type { ButtonProps as ReactNativeButtonProps } from 'react-native';
 
 const colors = {
   orange: '#ffbd59',
   green: '#82f152',
-  lightgreen: '#beffa2',
+  lightGreen: '#beffa2',
   red: '#f15e5e',
-  lightred: '#ffb7b7',
+  lightRed: '#ffb7b7',
 } as const;
 
 type Colors = keyof typeof colors;
@@ -20,6 +20,18 @@ type ButtonProps = {
 export function Button({ color, title, onPress }: ButtonProps): JSX.Element {
   const buttonColor = colors[color];
   return (
-    <ReactNativeButton title={title} onPress={onPress} color={buttonColor} />
+    // TODO: Could use a custom Pressable component to add styles, instead of a Button wrapped in a View.
+    <View style={styles.container}>
+      <ReactNativeButton title={title} onPress={onPress} color={buttonColor} />
+    </View>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    // Buttons should expand to fill available container space by default.
+    // Larger buttons are better for mobile touch targets.
+    flexBasis: 1,
+    flexGrow: 1,
+  },
+});

--- a/src/base/components/button/button.tsx
+++ b/src/base/components/button/button.tsx
@@ -1,28 +1,30 @@
 import { Button as ReactNativeButton, View, StyleSheet } from 'react-native';
 import type { ButtonProps as ReactNativeButtonProps } from 'react-native';
 
-const colors = {
+const buttonColours = {
   orange: '#ffbd59',
   green: '#82f152',
-  lightGreen: '#beffa2',
+  lightGreen: '#a0ff77',
+  veryLightGreen: '#aaff85',
   red: '#f15e5e',
   lightRed: '#ffb7b7',
+  veryLightRed: '#ffcfcf',
 } as const;
 
-type Colors = keyof typeof colors;
+export type ButtonColours = keyof typeof buttonColours;
 
 type ButtonProps = {
   title: ReactNativeButtonProps['title'];
   onPress: ReactNativeButtonProps['onPress'];
-  color: Colors;
+  color: ButtonColours;
 };
 
 export function Button({ color, title, onPress }: ButtonProps): JSX.Element {
-  const buttonColor = colors[color];
+  const buttonColour = buttonColours[color];
   return (
     // TODO: Could use a custom Pressable component to add styles, instead of a Button wrapped in a View.
     <View style={styles.container}>
-      <ReactNativeButton title={title} onPress={onPress} color={buttonColor} />
+      <ReactNativeButton title={title} onPress={onPress} color={buttonColour} />
     </View>
   );
 }

--- a/src/feed-parser/assertions.ts
+++ b/src/feed-parser/assertions.ts
@@ -1,3 +1,4 @@
+import { assert } from '../base/assert';
 import type { RssFeed } from './parser';
 
 type FeedMeta = {
@@ -28,19 +29,6 @@ type FeedItem = {
     'votes-neg': number;
   };
 };
-
-class AssertionError extends Error {
-  constructor(message?: string) {
-    super(message);
-    this.name = 'AssertionError';
-  }
-}
-
-function assert(value: boolean, message?: string): asserts value {
-  if (!value) {
-    throw new AssertionError(message);
-  }
-}
 
 export function assertFeedMeta(
   feed: RssFeed,

--- a/src/screens/dealInfo/__tests__/voteButtons.test.tsx
+++ b/src/screens/dealInfo/__tests__/voteButtons.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react-native';
+import { expectButtonColour } from '../../../base/components/button/__tests__/testHelpers';
+import { NegativeVoteButton, PositiveVoteButton } from '../voteButtons';
+
+describe('Buttons change colour based on amount of votes', () => {
+  const onPress = jest.fn();
+
+  test('Positive votes', () => {
+    render(
+      <>
+        <PositiveVoteButton votes={0} onPress={onPress} />
+        <PositiveVoteButton votes={5} onPress={onPress} />
+        <PositiveVoteButton votes={30} onPress={onPress} />
+      </>,
+    );
+
+    const buttons = screen.getAllByText('👍', { exact: false });
+
+    expectButtonColour(buttons[0], 'veryLightGreen');
+    expectButtonColour(buttons[1], 'lightGreen');
+    expectButtonColour(buttons[2], 'green');
+  });
+
+  test('Negative votes', () => {
+    render(
+      <>
+        <NegativeVoteButton votes={0} onPress={onPress} />
+        <NegativeVoteButton votes={1} onPress={onPress} />
+        <NegativeVoteButton votes={3} onPress={onPress} />
+      </>,
+    );
+
+    const buttons = screen.getAllByText('👎', { exact: false });
+
+    expectButtonColour(buttons[0], 'veryLightRed');
+    expectButtonColour(buttons[1], 'lightRed');
+    expectButtonColour(buttons[2], 'red');
+  });
+});

--- a/src/screens/dealInfo/__tests__/voteButtons.test.tsx
+++ b/src/screens/dealInfo/__tests__/voteButtons.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react-native';
+import { fireEvent, render, screen } from '@testing-library/react-native';
 import { expectButtonColour } from '../../../base/components/button/__tests__/testHelpers';
 import { NegativeVoteButton, PositiveVoteButton } from '../voteButtons';
 
@@ -35,5 +35,27 @@ describe('Buttons change colour based on amount of votes', () => {
     expectButtonColour(buttons[0], 'veryLightRed');
     expectButtonColour(buttons[1], 'lightRed');
     expectButtonColour(buttons[2], 'red');
+  });
+});
+
+describe('onPress fires with correct vote kind', () => {
+  test('Positive vote button', () => {
+    const onPress = jest.fn();
+    render(<PositiveVoteButton votes={0} onPress={onPress} />);
+
+    const button = screen.getByText('👍', { exact: false });
+    fireEvent.press(button);
+
+    expect(onPress).toHaveBeenCalledWith('positive');
+  });
+
+  test('Negative vote button', () => {
+    const onPress = jest.fn();
+    render(<NegativeVoteButton votes={0} onPress={onPress} />);
+
+    const button = screen.getByText('👎', { exact: false });
+    fireEvent.press(button);
+
+    expect(onPress).toHaveBeenCalledWith('negative');
   });
 });

--- a/src/screens/dealInfo/dealHeader.tsx
+++ b/src/screens/dealInfo/dealHeader.tsx
@@ -1,8 +1,8 @@
-import { Text, StyleSheet, View } from 'react-native';
-import { Button } from '../../base/components/button/button';
+import { Text, StyleSheet } from 'react-native';
 import { SquareImage } from '../../base/components/image/squareImage';
 import { Column, Row } from '../../base/layout/flex';
 import type { OzbargainFeed } from '../../feed-parser/parser';
+import { makeVoteButtons } from './voteButtons';
 
 type DealHeaderProps = {
   title: string;
@@ -21,6 +21,8 @@ export function DealHeader({
   imageUrl,
   votes,
 }: DealHeaderProps): JSX.Element {
+  const { positiveVoteButton, negativeVoteButton } = makeVoteButtons({ votes });
+
   return (
     <Row gap={16}>
       <Column gap={16} shrink={1} grow={1}>
@@ -48,32 +50,13 @@ export function DealHeader({
       <Column gap={16} justifyContent="flex-start">
         <SquareImage source={{ uri: imageUrl }} sizePx={140} />
         <Row gap={16}>
-          <View style={styles.buttonContainer}>
-            <Button
-              title={`👍 ${votes.positive}`}
-              color="green"
-              onPress={() => undefined}
-            />
-          </View>
-          <View style={styles.buttonContainer}>
-            <Button
-              title={`👎 ${votes.negative}`}
-              color="lightred"
-              onPress={() => undefined}
-            />
-          </View>
+          {positiveVoteButton}
+          {negativeVoteButton}
         </Row>
       </Column>
     </Row>
   );
 }
-
-const styles = StyleSheet.create({
-  buttonContainer: {
-    flexBasis: 1,
-    flexGrow: 1,
-  },
-});
 
 const textStyles = StyleSheet.create({
   title: {

--- a/src/screens/dealInfo/voteButtons.tsx
+++ b/src/screens/dealInfo/voteButtons.tsx
@@ -1,0 +1,45 @@
+import { Button } from '../../base/components/button/button';
+import type { OzbargainFeed } from '../../feed-parser/parser';
+
+type VoteButtonsProps = {
+  votes: OzbargainFeed['deals'][number]['votes'];
+};
+type OnPress = {
+  onPress: () => Promise<void>;
+};
+
+// TODO: When the app supports logging in, add API call here to submit a vote.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/require-await
+const submitVote = async (kind: 'positive' | 'negative') => undefined;
+
+export function makeVoteButtons({ votes }: VoteButtonsProps): {
+  positiveVoteButton: JSX.Element;
+  negativeVoteButton: JSX.Element;
+} {
+  return {
+    positiveVoteButton: PositiveVoteButton({
+      ...votes,
+      onPress: () => submitVote('positive'),
+    }),
+    negativeVoteButton: NegativeVoteButton({
+      ...votes,
+      onPress: () => submitVote('negative'),
+    }),
+  };
+}
+
+function PositiveVoteButton({
+  positive,
+  onPress,
+}: VoteButtonsProps['votes'] & OnPress): JSX.Element {
+  const title = `👍 ${positive}`;
+  return <Button title={title} color="green" onPress={onPress} />;
+}
+
+function NegativeVoteButton({
+  negative,
+  onPress,
+}: VoteButtonsProps['votes'] & OnPress): JSX.Element {
+  const title = `👎 ${negative}`;
+  return <Button title={title} color="lightRed" onPress={onPress} />;
+}

--- a/src/screens/dealInfo/voteButtons.tsx
+++ b/src/screens/dealInfo/voteButtons.tsx
@@ -1,3 +1,4 @@
+import type { ButtonColours } from '../../base/components/button/button';
 import { Button } from '../../base/components/button/button';
 import type { OzbargainFeed } from '../../feed-parser/parser';
 
@@ -7,10 +8,11 @@ type VoteButtonsProps = {
 type OnPress = {
   onPress: () => Promise<void>;
 };
+type VoteKind = 'positive' | 'negative';
 
 // TODO: When the app supports logging in, add API call here to submit a vote.
 // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/require-await
-const submitVote = async (kind: 'positive' | 'negative') => undefined;
+const submitVote = async (kind: VoteKind) => undefined;
 
 export function makeVoteButtons({ votes }: VoteButtonsProps): {
   positiveVoteButton: JSX.Element;
@@ -28,12 +30,32 @@ export function makeVoteButtons({ votes }: VoteButtonsProps): {
   };
 }
 
+function getColourForVoteCount(kind: VoteKind, count: number): ButtonColours {
+  if (kind === 'positive') {
+    // Thresholds decided based on personal experience with how often deals are positively voted.
+    // eslint-disable-next-line no-nested-ternary, prettier/prettier
+    return count < 5
+        ? 'veryLightGreen'
+        : count < 30
+            ? 'lightGreen'
+            : 'green';
+  }
+  // Negative votes are very rare on deals, so the thresholds are much lower.
+  // eslint-disable-next-line no-nested-ternary, prettier/prettier
+  return count < 1
+      ? 'veryLightRed'
+      : count < 3
+          ? 'lightRed'
+          : 'red';
+}
+
 function PositiveVoteButton({
   positive,
   onPress,
 }: VoteButtonsProps['votes'] & OnPress): JSX.Element {
   const title = `👍 ${positive}`;
-  return <Button title={title} color="green" onPress={onPress} />;
+  const colour = getColourForVoteCount('positive', positive);
+  return <Button title={title} color={colour} onPress={onPress} />;
 }
 
 function NegativeVoteButton({
@@ -41,5 +63,6 @@ function NegativeVoteButton({
   onPress,
 }: VoteButtonsProps['votes'] & OnPress): JSX.Element {
   const title = `👎 ${negative}`;
-  return <Button title={title} color="lightRed" onPress={onPress} />;
+  const colour = getColourForVoteCount('negative', negative);
+  return <Button title={title} color={colour} onPress={onPress} />;
 }

--- a/src/screens/dealInfo/voteButtons.tsx
+++ b/src/screens/dealInfo/voteButtons.tsx
@@ -20,11 +20,11 @@ export function makeVoteButtons({ votes }: VoteButtonsProps): {
 } {
   return {
     positiveVoteButton: PositiveVoteButton({
-      ...votes,
+      votes: votes.positive,
       onPress: () => submitVote('positive'),
     }),
     negativeVoteButton: NegativeVoteButton({
-      ...votes,
+      votes: votes.negative,
       onPress: () => submitVote('negative'),
     }),
   };
@@ -49,20 +49,22 @@ function getColourForVoteCount(kind: VoteKind, count: number): ButtonColours {
           : 'red';
 }
 
-function PositiveVoteButton({
-  positive,
+/** Exported for testing. */
+export function PositiveVoteButton({
+  votes,
   onPress,
-}: VoteButtonsProps['votes'] & OnPress): JSX.Element {
-  const title = `👍 ${positive}`;
-  const colour = getColourForVoteCount('positive', positive);
+}: { votes: VoteButtonsProps['votes']['positive'] } & OnPress): JSX.Element {
+  const title = `👍 ${votes}`;
+  const colour = getColourForVoteCount('positive', votes);
   return <Button title={title} color={colour} onPress={onPress} />;
 }
 
-function NegativeVoteButton({
-  negative,
+/** Exported for testing. */
+export function NegativeVoteButton({
+  votes,
   onPress,
-}: VoteButtonsProps['votes'] & OnPress): JSX.Element {
-  const title = `👎 ${negative}`;
-  const colour = getColourForVoteCount('negative', negative);
+}: { votes: VoteButtonsProps['votes']['negative'] } & OnPress): JSX.Element {
+  const title = `👎 ${votes}`;
+  const colour = getColourForVoteCount('negative', votes);
   return <Button title={title} color={colour} onPress={onPress} />;
 }

--- a/src/screens/dealInfo/voteButtons.tsx
+++ b/src/screens/dealInfo/voteButtons.tsx
@@ -19,14 +19,12 @@ export function makeVoteButtons({ votes }: VoteButtonsProps): {
   negativeVoteButton: JSX.Element;
 } {
   return {
-    positiveVoteButton: PositiveVoteButton({
-      votes: votes.positive,
-      onPress: submitVote,
-    }),
-    negativeVoteButton: NegativeVoteButton({
-      votes: votes.negative,
-      onPress: submitVote,
-    }),
+    positiveVoteButton: (
+      <PositiveVoteButton votes={votes.positive} onPress={submitVote} />
+    ),
+    negativeVoteButton: (
+      <NegativeVoteButton votes={votes.negative} onPress={submitVote} />
+    ),
   };
 }
 

--- a/src/screens/dealInfo/voteButtons.tsx
+++ b/src/screens/dealInfo/voteButtons.tsx
@@ -5,10 +5,10 @@ import type { OzbargainFeed } from '../../feed-parser/parser';
 type VoteButtonsProps = {
   votes: OzbargainFeed['deals'][number]['votes'];
 };
-type OnPress = {
-  onPress: () => Promise<void>;
-};
 type VoteKind = 'positive' | 'negative';
+type OnPress = {
+  onPress: (kind: VoteKind) => Promise<void>;
+};
 
 // TODO: When the app supports logging in, add API call here to submit a vote.
 // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/require-await
@@ -21,11 +21,11 @@ export function makeVoteButtons({ votes }: VoteButtonsProps): {
   return {
     positiveVoteButton: PositiveVoteButton({
       votes: votes.positive,
-      onPress: () => submitVote('positive'),
+      onPress: submitVote,
     }),
     negativeVoteButton: NegativeVoteButton({
       votes: votes.negative,
-      onPress: () => submitVote('negative'),
+      onPress: submitVote,
     }),
   };
 }
@@ -56,7 +56,9 @@ export function PositiveVoteButton({
 }: { votes: VoteButtonsProps['votes']['positive'] } & OnPress): JSX.Element {
   const title = `👍 ${votes}`;
   const colour = getColourForVoteCount('positive', votes);
-  return <Button title={title} color={colour} onPress={onPress} />;
+  return (
+    <Button title={title} color={colour} onPress={() => onPress('positive')} />
+  );
 }
 
 /** Exported for testing. */
@@ -66,5 +68,7 @@ export function NegativeVoteButton({
 }: { votes: VoteButtonsProps['votes']['negative'] } & OnPress): JSX.Element {
   const title = `👎 ${votes}`;
   const colour = getColourForVoteCount('negative', votes);
-  return <Button title={title} color={colour} onPress={onPress} />;
+  return (
+    <Button title={title} color={colour} onPress={() => onPress('negative')} />
+  );
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,8 @@
     "strict": true
   },
   "include": [
-    "src/"
+    "src/",
+    // Lets Typescript/intellisense know about the extra `expect` matchers added.
+    "jest.setup-after-env.ts"
   ]
 }


### PR DESCRIPTION
- Extract vote buttons to their own components in `voteButtons.ts`.
- Vote Buttons change colours between 3 levels of intensity based on amount of votes.
    - Intensity thresholds are different for positive and negative buttons because negative votes are much rarer on deals.
    - Thresholds were picked based on personal experience.
- Add unit tests for the vote buttons.

Apart from colour changing, there is no difference in the vote buttons' looks in this PR.