### PR TITLE
Add EAS Build Github action workflow for building a preview of the android app

### DIFF
--- a/.github/workflows/easBuild.yml
+++ b/.github/workflows/easBuild.yml
@@ -1,0 +1,34 @@
+name: EAS Build
+run-name: '${{ github.workflow }} - Requested by @${{github.actor}} (Run #${{github.run_number}})'
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  build-android-preview:
+    name: Build Android (Preview)
+    if: |
+      ${{
+        github.event.issue.pull_request &&
+        github.event.comment.user.name == 'josh-leyshon' &&
+        contains(github.event.comment.body, '🏗 build-android-preview')
+      }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+          cache: npm
+
+      - name: Setup EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          packager: npm
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: 🏗 Build on EAS
+        run: eas build --platform android --profile preview --non-interactive

--- a/.github/workflows/easBuild.yml
+++ b/.github/workflows/easBuild.yml
@@ -9,7 +9,7 @@ jobs:
     if: |
       ${{
         github.event.issue.pull_request &&
-        github.event.comment.user.name == 'josh-leyshon' &&
+        github.event.comment.user.login == 'josh-leyshon' &&
         contains(github.event.comment.body, '🏗 build-android-preview')
       }}
     runs-on: ubuntu-latest

--- a/app.json
+++ b/app.json
@@ -24,7 +24,8 @@
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#FFFFFF"
-      }
+      },
+      "package": "com.josh_leyshon.ozbargain"
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/app.json
+++ b/app.json
@@ -14,7 +14,9 @@
     "updates": {
       "fallbackToCacheTimeout": 0
     },
-    "assetBundlePatterns": ["**/*"],
+    "assetBundlePatterns": [
+      "**/*"
+    ],
     "ios": {
       "supportsTablet": true
     },
@@ -26,6 +28,11 @@
     },
     "web": {
       "favicon": "./assets/favicon.png"
+    },
+    "extra": {
+      "eas": {
+        "projectId": "d0403539-b262-43fb-8bf5-25a9277b9181"
+      }
     }
   }
 }

--- a/eas.json
+++ b/eas.json
@@ -1,0 +1,18 @@
+{
+  "cli": {
+    "version": ">= 5.4.0"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal"
+    },
+    "preview": {
+      "distribution": "internal"
+    },
+    "production": {}
+  },
+  "submit": {
+    "production": {}
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint:types": "tsc",
     "build": "expo export",
     "build:web": "expo export:web",
+    "build:android:preview:local": "npx eas-cli build -p android --profile preview --local",
     "ts-node": "ts-node --files",
     "regen-patches": "patch-package rss-parser --exclude='lib' --include 'package\\.json'",
     "postinstall": "patch-package",


### PR DESCRIPTION
- Configure the project for EAS builds with new `eas.json`.
- The `build-android-preview` job is currently the only one within the `EAS Build` workflow. It can only be triggered by certain users (me) leaving a comment on a PR that includes the text `🏗 build-android-preview`.
- Also added the `build:android:preview:local` package script to build the same target locally.