### PR TITLE
Fix EAS Build workflow so it builds the requesting PR branch

### DIFF
--- a/.github/workflows/easBuild.yml
+++ b/.github/workflows/easBuild.yml
@@ -14,8 +14,21 @@ jobs:
       }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - name: Get PR branch
+        uses: xt0rted/pull-request-comment-branch@v2
+        id: pr-branch-info
+      
+      - name: Set commit status as pending
+        uses: myrotvorets/set-commit-status-action@v2.0.1
+        with:
+          sha: ${{ steps.pr-branch-info.head_sha }}
+          status: pending
+
+      - name: Checkout PR branch
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
         with:
           node-version: 18.x
           cache: npm
@@ -32,3 +45,10 @@ jobs:
 
       - name: 🏗 Build on EAS
         run: eas build --platform android --profile preview --non-interactive
+      
+      - name: Set final commit status
+        uses: myrotvorets/set-commit-status-action@v2.0.1
+        if: always()
+        with:
+          sha: ${{ steps.pr-branch-info.head_sha }}
+          status: ${{ job.status }}

--- a/.github/workflows/easBuild.yml
+++ b/.github/workflows/easBuild.yml
@@ -27,10 +27,10 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@v3
 
-      - name: Setup Node
+      - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 20.x
           cache: npm
 
       - name: Setup EAS

--- a/.github/workflows/easBuild.yml
+++ b/.github/workflows/easBuild.yml
@@ -1,6 +1,7 @@
 name: EAS Build
 run-name: '${{ github.workflow }} - Requested by @${{github.actor}} (Run #${{github.run_number}})'
 on:
+  workflow_dispatch:
   issue_comment:
     types: [created]
 jobs:
@@ -15,10 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get PR branch
+        if: github.event_name != 'workflow_dispatch'
         uses: xt0rted/pull-request-comment-branch@v2
         id: pr-branch-info
       
       - name: Set commit status as pending
+        if: github.event_name != 'workflow_dispatch'
         uses: myrotvorets/set-commit-status-action@v2.0.1
         with:
           sha: ${{ steps.pr-branch-info.head_sha }}
@@ -26,6 +29,13 @@ jobs:
 
       - name: Checkout PR branch
         uses: actions/checkout@v3
+        with:
+          ref: |
+            ${{
+              github.event_name != 'workflow_dispatch' &&
+              steps.comment-branch.outputs.head_ref ||
+              github.sha
+            }}
 
       - name: Install Node
         uses: actions/setup-node@v3

--- a/.github/workflows/easBuild.yml
+++ b/.github/workflows/easBuild.yml
@@ -58,7 +58,7 @@ jobs:
       
       - name: Set final commit status
         uses: myrotvorets/set-commit-status-action@v2.0.1
-        if: always()
+        if: always() && github.event_name != 'workflow_dispatch'
         with:
           sha: ${{ steps.pr-branch-info.head_sha }}
           status: ${{ job.status }}

--- a/.github/workflows/lintTestBuild.yml
+++ b/.github/workflows/lintTestBuild.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: 20.x
           cache: npm
       - name: Install deps
         run: npm ci
@@ -35,7 +35,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: 20.x
           cache: npm
       - name: Install deps
         run: npm ci
@@ -52,7 +52,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: 20.x
           cache: npm
       - name: Install deps
         run: npm ci
@@ -69,7 +69,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: 20.x
           cache: npm
       - name: Install deps
         run: npm ci

--- a/app.json
+++ b/app.json
@@ -34,6 +34,7 @@
       "eas": {
         "projectId": "d0403539-b262-43fb-8bf5-25a9277b9181"
       }
-    }
+    },
+    "owner": "ekswhyzed"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "private": true,
   "volta": {
     "node": "20.13.1",
-    "npm": "10.8.0"
+    "// npm v10.8.0 breaks --json outputs": "",
+    "npm": "10.7.0"
   },
   "scripts": {
     "start": "expo start --tunnel",


### PR DESCRIPTION
Follows on from #24. The workflow could be run (see [comment](https://github.com/josh-leyshon/ozbargain/pull/26#issuecomment-2129296088) and [build](https://github.com/josh-leyshon/ozbargain/actions/runs/9223182874/job/25375862051)), but would build `master` branch instead of the PR branch the comment came from. There would be no indication on the PR that the workflow was running.

This PR should fix that.

Roughly followed this guide: https://dev.to/zirkelc/trigger-github-workflow-for-comment-on-pull-request-45l2

Uses two Github Action containers:
- https://github.com/xt0rted/pull-request-comment-branch
- https://github.com/myrotvorets/set-commit-status-action

Unfortunately, the `issue_comment` workflow trigger only works when the workflow file is on the default branch (`master`). That means that I can't test these changes until I merge this PR to `master`, and then leave a comment on a different PR.