### PR TITLE
Trim long comments for performance

### DIFF
--- a/src/base/components/text/textParts/commonTextFromParts.tsx
+++ b/src/base/components/text/textParts/commonTextFromParts.tsx
@@ -8,6 +8,7 @@ import { Blockquote } from '../blockquote';
 import { Link } from '../link';
 import type { TextProps } from '../text';
 import { Text } from '../text';
+import { groupTextPartsIntoRenderableGroups, trimTextParts } from './utils';
 
 type CommonTextFromPartsProps = {
   textParts: TextPart[];
@@ -19,7 +20,8 @@ type CommonTextFromPartsProps = {
  * This component handles that.
  */
 export function CommonTextFromParts({ textParts, ...props }: CommonTextFromPartsProps): React.JSX.Element {
-  const groups = groupTextPartsIntoRenderableGroups(textParts);
+  const trimmedTextParts = trimTextParts(textParts);
+  const groups = groupTextPartsIntoRenderableGroups(trimmedTextParts);
 
   return (
     <Column>
@@ -78,39 +80,4 @@ function SingleTextPart({ textPart, size, weight, colour }: RenderTextPartProps)
         {textPart.text}
       </Text>
     );
-}
-
-/**
- * For different types of TextParts to be rendered visibly "together",
- * they need to be grouped into appropriate groups that can be rendered together in one view.
- *
- * For example, a `blockquote` type needs to be rendered in its own group, because
- * it won't render correctly as inline Text like simpler types (it will overflow oddly).
- *
- * Other types may be fine, and in fact are required, to be rendered within the same Text view,
- * for text wrapping to occur correctly.
- */
-function groupTextPartsIntoRenderableGroups(textParts: TextPart[]): TextPart[][] {
-  const groups: TextPart[][] = [];
-
-  let currentGroup: TextPart[] = [];
-
-  for (const part of textParts) {
-    if (part.type === 'blockquote') {
-      if (currentGroup.length > 0) {
-        groups.push(currentGroup);
-      }
-      groups.push([part]);
-      currentGroup = [];
-      continue;
-    }
-
-    currentGroup.push(part);
-  }
-
-  if (currentGroup.length > 0) {
-    groups.push(currentGroup);
-  }
-
-  return groups;
 }

--- a/src/base/components/text/textParts/utils.ts
+++ b/src/base/components/text/textParts/utils.ts
@@ -1,0 +1,63 @@
+import type { TextPart } from '../../../../parsers/text/textParts';
+
+const maxNumTextParts = 80;
+
+/**
+ * Limiting the number of text parts to render is a performance optimization.
+ * Most deal descriptions have around 10 parts. Outliers have 100s.
+ * Rendering a large text section can visibly lag the app.
+ */
+export function trimTextParts(textParts: TextPart[]): TextPart[] {
+  return textParts.length > maxNumTextParts
+    ? [
+      ...textParts.slice(0, maxNumTextParts),
+      makeTrimmedTextPart(textParts.at(maxNumTextParts)?.endIndex ?? -1),
+    ]
+    : textParts;
+}
+
+function makeTrimmedTextPart(startIndex: number): TextPart {
+  const text = '\n\n...(trimmed)';
+  return {
+    type: 'normal',
+    rawText: text,
+    text,
+    startIndex,
+    endIndex: startIndex + text.length,
+  };
+}
+
+/**
+ * For different types of TextParts to be rendered visibly "together",
+ * they need to be grouped into appropriate groups that can be rendered together in one view.
+ *
+ * For example, a `blockquote` type needs to be rendered in its own group, because
+ * it won't render correctly as inline Text like simpler types (it will overflow oddly).
+ *
+ * Other types may be fine, and in fact are required, to be rendered within the same Text view,
+ * for text wrapping to occur correctly.
+ */
+export function groupTextPartsIntoRenderableGroups(textParts: TextPart[]): TextPart[][] {
+  const groups: TextPart[][] = [];
+
+  let currentGroup: TextPart[] = [];
+
+  for (const part of textParts) {
+    if (part.type === 'blockquote') {
+      if (currentGroup.length > 0) {
+        groups.push(currentGroup);
+      }
+      groups.push([part]);
+      currentGroup = [];
+      continue;
+    }
+
+    currentGroup.push(part);
+  }
+
+  if (currentGroup.length > 0) {
+    groups.push(currentGroup);
+  }
+
+  return groups;
+}

--- a/src/screens/dealInfo/description.tsx
+++ b/src/screens/dealInfo/description.tsx
@@ -1,33 +1,9 @@
 import type React from 'react';
 import { CommonTextFromParts } from '../../base/components/text/textParts/commonTextFromParts';
-import type { TextPart } from '../../parsers/text/textParts';
 import type { Deal } from '../../parsers/xml-feed/parser';
-
-const maxNumTextParts = 80;
 
 type DescriptionProps = Pick<Deal, 'description'>;
 
 export function Description({ description }: DescriptionProps): React.JSX.Element {
-  // Limiting the number of text parts to render is a performance optimization.
-  // Most deal descriptions have around 10 parts. Outliers have 100s.
-  // Rendering a large description can visibly lag the app.
-  const parts = description.parts.length > maxNumTextParts
-    ? [
-      ...description.parts.slice(0, maxNumTextParts),
-      makeTrimmedDescriptionTextPart(description.parts.at(maxNumTextParts)?.endIndex ?? -1),
-    ]
-    : description.parts;
-
-  return <CommonTextFromParts textParts={parts} />;
-}
-
-function makeTrimmedDescriptionTextPart(startIndex: number): TextPart {
-  const text = '\n\n...(description trimmed)';
-  return {
-    type: 'normal',
-    rawText: text,
-    text,
-    startIndex,
-    endIndex: startIndex + text.length,
-  };
+  return <CommonTextFromParts textParts={description.parts} />;
 }


### PR DESCRIPTION
Rendering a very long comment (one with lots of `TextPart`s) will hang the app while React tries to render it. It's just the rendering process that is slow, not fetching/parsing. And once it has rendered, scrolling the app and viewing that long comment has fine performance.

This PR extracts the trimming logic used in `Description` out to be used in `CommonTextFromParts` instead, so that comments can use it too.

Example long comment that hangs the app: https://www.ozbargain.com.au/node/893636#comment-16266806